### PR TITLE
feat: Use elevated privileges when required and fix config update interval

### DIFF
--- a/cmd/pingsheet/main.go
+++ b/cmd/pingsheet/main.go
@@ -69,7 +69,8 @@ func main() {
 		*secret,      // Secret
 	)
 	if err != nil {
-		fmt.Printf("Error: %s", err)
+		log.Error().Msgf("Error: %s\n", err)
+		os.Exit(1)
 	}
 	p.Run()
 }

--- a/pingsheet.go
+++ b/pingsheet.go
@@ -64,7 +64,7 @@ func (p *Pingsheet) Run() {
 	configTime := time.Now()
 	for {
 		// Pull new config
-		if time.Since(configTime) >= time.Duration(configPullInterval*time.Now().Second()) {
+		if time.Since(configTime) >= time.Duration(configPullInterval)*time.Second {
 			updateTime := time.Now()
 			log.Info().Msgf("Config update start")
 			err := p.pullLatestConfig()

--- a/pingsheet.go
+++ b/pingsheet.go
@@ -51,6 +51,7 @@ func NewPingsheet(sheetID, keyPath, hostname, secret string) (*Pingsheet, error)
 		log.Error().Msgf("Error registering host: %s", err)
 		os.Exit(1)
 	}
+	log.Info().Msgf("Registration successful")
 	return p, nil
 }
 


### PR DESCRIPTION
# What
* Add logic for checking if privileges are required and if they are then check if they are present and use them.
* When an error is encountered then exit the `pingsheet` cli tool
* Add helpful message telling user that registration has been successful.

# Why
* Because tool was not working correctly on Linux due to privileges being required. This way we can check if privileges are required and only use them when required rather than all the time.
* So that if there is an issue the tool exits and does not continue which ends up being more confusing as you run into other errors.