### PR TITLE
docs: update installation untar command

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,14 +24,14 @@ term data.
    * Mac OS
      ```
      wget https://github.com/adamkirchberger/pingsheet/releases/latest/download/pingsheet_Darwin_x86_64.tar.gz && \
-     tar xvzf pingsheet_Darwin_x86_64.tar.gz && \
+     tar xvzf pingsheet_Darwin_x86_64.tar.gz pingsheet && \
      xattr -dr com.apple.quarantine pingsheet && \
      mv pingsheet /usr/local/sbin/
      ```
    * Linux
      ```
      wget https://github.com/adamkirchberger/pingsheet/releases/latest/download/pingsheet_Linux_x86_64.tar.gz && \
-     tar xvzf pingsheet_Linux_x86_64.tar.gz && \
+     tar xvzf pingsheet_Linux_x86_64.tar.gz pingsheet && \
      mv pingsheet /usr/local/sbin/
      ```
 5. Run the tool


### PR DESCRIPTION
# What
* Update untar command to only untar single binary file.

# Why
* So that other files which aren't necessary don't get extracted when not required which can be a bit messy.